### PR TITLE
Add GitHub workflows and JSON schema for the definition files

### DIFF
--- a/.github/supporting-files/combine-sample-definitions.js
+++ b/.github/supporting-files/combine-sample-definitions.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const SAMPLES_FOLDER_NAME = "samples";
+const DEFINITION_FILE_NAME = "definition.json";
+const TEMPLATE_FOLDER_NAME = "template";
+const SAMPLE_DEFINITIONS_FILE_NAME = "sample-definitions.json";
+
+const samplesDir = path.join(__dirname, "..", "..", SAMPLES_FOLDER_NAME);
+const subdirs = fs
+  .readdirSync(samplesDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && d.name !== TEMPLATE_FOLDER_NAME)
+  .map((d) => d.name);
+
+const definitions = subdirs.flatMap((sample) => {
+  const definitionPath = path.join(samplesDir, sample, DEFINITION_FILE_NAME);
+  if (!fs.existsSync(definitionPath)) {
+    console.error(`${definitionPath} does not exist.`);
+    process.exit(1);
+  }
+  const contents = fs.readFileSync(definitionPath);
+  const sampleRelativePath = path.join(SAMPLES_FOLDER_NAME, sample);
+  return { ...JSON.parse(contents), sample_path: sampleRelativePath };
+});
+
+const outputFilePath = path.join(__dirname, SAMPLE_DEFINITIONS_FILE_NAME);
+fs.writeFileSync(outputFilePath, JSON.stringify(definitions, null, 2));
+console.log(
+  `Merged ${definitions.length} definition files into ${outputFilePath}`
+);

--- a/.github/supporting-files/schema.json
+++ b/.github/supporting-files/schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema.json",
+  "type": "object",
+  "title": "Definition",
+  "description": "Schema for a Definition object",
+  "required": [
+    "type",
+    "category",
+    "status",
+    "title",
+    "description",
+    "cover",
+    "tags",
+    "authors"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["sample", "pattern"]
+    },
+    "category": {
+      "type": "string",
+      "enum": ["serverless-workflow", "serverless-decision", "dashbuilder"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "out of date", "deprecated"]
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "cover": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "related_to": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["video", "documentation", "link"]
+          },
+          "title": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["type", "title", "text", "url"]
+      }
+    },
+    "authors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          },
+          "github": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "social": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "network": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": ["network", "id"]
+            }
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  }
+}

--- a/.github/supporting-files/validate-sample-definitions.js
+++ b/.github/supporting-files/validate-sample-definitions.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const Ajv = require("ajv");
+
+const SAMPLE_SCHEMA_FILE_NAME = "schema.json";
+const DEFINITION_FILE_NAME = "definition.json";
+const SAMPLES_FOLDER_NAME = "samples";
+const TEMPLATE_FOLDER_NAME = "template";
+
+const ajv = new Ajv({ allErrors: true });
+
+const schemaPath = path.join(__dirname, SAMPLE_SCHEMA_FILE_NAME);
+const schema = JSON.parse(fs.readFileSync(schemaPath));
+
+const samplesDir = path.join(__dirname, "..", "..", SAMPLES_FOLDER_NAME);
+const subdirs = fs
+  .readdirSync(samplesDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && d.name !== TEMPLATE_FOLDER_NAME)
+  .map((d) => d.name);
+
+for (const subdir of subdirs) {
+  const definitionPath = path.join(samplesDir, subdir, DEFINITION_FILE_NAME);
+  const definition = JSON.parse(fs.readFileSync(definitionPath));
+
+  const isValid = ajv.validate(schema, definition);
+
+  if (!isValid) {
+    console.error(
+      `Validation failed for definition in ${subdir}/${DEFINITION_FILE_NAME}`
+    );
+    console.error(ajv.errorsText());
+    process.exit(1);
+  }
+
+  const coverPath = path.join(samplesDir, subdir, definition.cover);
+  if (!fs.existsSync(coverPath)) {
+    console.error(
+      `Cover file specified in ${subdir}/${DEFINITION_FILE_NAME} does not exist: ${definition.cover}`
+    );
+    process.exit(1);
+  }
+}

--- a/.github/workflows/combine-sample-definitions.yml
+++ b/.github/workflows/combine-sample-definitions.yml
@@ -1,0 +1,40 @@
+name: "Combine Sample Definitions"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "samples/**"
+
+jobs:
+  merge_definitions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.KIE_TOOLS_BOT_TOKEN }}
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: "Install dependencies"
+        run: npm install ajv@8.12.0
+
+      - name: "Validate sample definition files"
+        run: node .github/supporting-files/validate-sample-definitions.js
+
+      - name: "Combine sample definitions"
+        run: node .github/supporting-files/combine-sample-definitions.js
+
+      - name: "Commit and push"
+        run: |
+          git config --global user.email "kietoolsbot@gmail.com"
+          git config --global user.name "KIE Tools Bot (kiegroup)"
+          git add .github/supporting-files/sample-definitions.json
+          git commit -m "Update sample definitions" || echo "No changes."
+          git push origin main

--- a/.github/workflows/sample-validation.yml
+++ b/.github/workflows/sample-validation.yml
@@ -1,0 +1,23 @@
+name: "Sample Validation"
+
+on:
+  pull_request:
+
+jobs:
+  check_definitions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: "Install dependencies"
+        run: npm install ajv@8.12.0
+
+      - name: "Validate sample definition files"
+        run: node .github/supporting-files/validate-sample-definitions.js


### PR DESCRIPTION
In this PR:
- A JSON schema based on the `definition.json` file we have.
- GitHub workflow "Sample Validation": This workflow is triggered on every PR and validates each `definition.json` against the JSON schema.
- GitHub workflow "Combine Sample Definitions": This workflow is triggered when there is a push that changes something in the samples folder. It combines all `definition.json` files in a single file and pushes it back to the repository. This is meant for 2 reasons: 1) apps like kubesmarts can fetch all definitions with only one rest call and 2) this enables apps like kubesmarts to have features like pagination, filter, and search more efficiently.

Before merging this PR, the `KIE_TOOLS_BOT_TOKEN` secret must be added so that the workflow can push changes back to the repository.