### PR TITLE
Update dashbuilder-kitchensink.dash.yaml

### DIFF
--- a/samples/dashbuilder-kitchensink/dashbuilder-kitchensink.dash.yaml
+++ b/samples/dashbuilder-kitchensink/dashbuilder-kitchensink.dash.yaml
@@ -793,10 +793,10 @@ navTree:
     - type: GROUP
       id: MainGroup
       children:
+        - page: Displayers 
         - page: Layout
         - page: HTML & CSS
-        - page: Data Sets
-        - page: Displayers
+        - page: Data Sets        
         - page: External Components
         - page: Navigation
         - page: Settings and Global


### PR DESCRIPTION
Making displayers the default page